### PR TITLE
allow to pass the `network` field of a `dmetering.Event`

### DIFF
--- a/file/config.go
+++ b/file/config.go
@@ -50,9 +50,6 @@ func newConfig(configURL string) (*Config, error) {
 	}
 
 	c.Network = vals.Get("network")
-	if c.Network == "" {
-		return nil, fmt.Errorf("network not specified (as query param)")
-	}
 
 	c.Source = vals.Get("source")
 

--- a/file/config_test.go
+++ b/file/config_test.go
@@ -31,6 +31,14 @@ func TestConfig_new(t *testing.T) {
 				BufferSize:           25,
 			},
 		},
+		{
+			dsn: "file:///tmp/test?buffer=25&flushIntervalSeconds=10",
+			expect: &Config{
+				BasePath:             "/tmp/test",
+				FlushIntervalSeconds: 10,
+				BufferSize:           25,
+			},
+		},
 	}
 
 	for _, test := range tests {

--- a/file/emitter.go
+++ b/file/emitter.go
@@ -81,7 +81,7 @@ func (e *emitter) launch() {
 				e.logger.Error("failed to flush", zap.Error(err))
 			}
 		case ev := <-e.buffer:
-			e.activeBatch = append(e.activeBatch, ev.ToProto(e.config.Network))
+			e.activeBatch = append(e.activeBatch, ev.ToProto())
 		}
 	}
 }

--- a/file/emitter.go
+++ b/file/emitter.go
@@ -92,6 +92,10 @@ func (e *emitter) Emit(_ context.Context, ev dmetering.Event) {
 		return
 	}
 
+	if e.config.Network != "" {
+		ev.Network = e.config.Network
+	}
+
 	select {
 	case e.buffer <- ev:
 	default:

--- a/grpc/config.go
+++ b/grpc/config.go
@@ -34,9 +34,6 @@ func newConfig(configURL string) (*Config, error) {
 
 	vals := u.Query()
 	c.Network = vals.Get("network")
-	if c.Network == "" {
-		return nil, fmt.Errorf("network not specified (as query param)")
-	}
 
 	bufferValue := vals.Get("buffer")
 	if bufferValue != "" {

--- a/grpc/config_test.go
+++ b/grpc/config_test.go
@@ -43,6 +43,14 @@ func TestConfig_new(t *testing.T) {
 			},
 		},
 		{
+			dsn: "grpc://localhost:9010?buffer=100000&delay=250",
+			expect: &Config{
+				Endpoint:   "localhost:9010",
+				Delay:      250 * time.Millisecond,
+				BufferSize: 100000,
+			},
+		},
+		{
 			dsn:         "grpc:localhost9010?buffer=100000&network=eth-mainnet&panicOnDrop=true",
 			expectError: true,
 		},

--- a/grpc/emitter.go
+++ b/grpc/emitter.go
@@ -92,7 +92,7 @@ func (e *emitter) launch() {
 			e.emit(e.activeBatch)
 			e.activeBatch = []*pbmetering.Event{}
 		case ev := <-e.buffer:
-			e.activeBatch = append(e.activeBatch, ev.ToProto(e.config.Network))
+			e.activeBatch = append(e.activeBatch, ev.ToProto())
 		}
 	}
 }
@@ -108,7 +108,7 @@ func (e *emitter) flushAndCloseEvent() {
 
 	for {
 		ev, ok := <-e.buffer
-		protoEv := ev.ToProto(e.config.Network)
+		protoEv := ev.ToProto()
 		if !ok {
 			e.logger.Info("sending last events", zap.Int("count", len(e.activeBatch)))
 			e.emit(e.activeBatch)
@@ -121,6 +121,14 @@ func (e *emitter) flushAndCloseEvent() {
 func (e *emitter) Emit(_ context.Context, ev dmetering.Event) {
 	if ev.Endpoint == "" {
 		e.logger.Warn("events must contain endpoint, dropping event", zap.Object("event", ev))
+		return
+	}
+
+	if e.config.Network != "" {
+		ev.Network = e.config.Network
+	}
+	if ev.Network == "" {
+		e.logger.Warn("network needs to be configured globally or events must contain network , dropping event", zap.Object("event", ev))
 		return
 	}
 

--- a/grpc/emitter_test.go
+++ b/grpc/emitter_test.go
@@ -159,3 +159,32 @@ func TestNetworkIncluded(t *testing.T) {
 	assert.Equal(t, 1, len(eventClient.eventsReceived))
 	assert.Equal(t, "eth-mainnet", eventClient.eventsReceived[0].Network)
 }
+
+func TestNetworkMissing(t *testing.T) {
+
+	ctx := context.Background()
+	eventClient := &mockClient{}
+
+	config := &Config{
+		Endpoint:   "localhost:9000",
+		Delay:      100 * time.Millisecond,
+		BufferSize: 100,
+	}
+	plugin, err := newWithClient(config, eventClient, eventClient.Close, zlog)
+	require.NoError(t, err)
+
+	plugin.Emit(ctx, dmetering.Event{
+		Endpoint: "sf.firehose.v1/Blocks",
+		Metrics: map[string]float64{
+			"requests": 1,
+		},
+		UserID:    "0bizy1111111111111111",
+		ApiKeyID:  "2323232323232323232323232323232323232323232323232323232323232323",
+		IpAddress: "192.168.1.1",
+		Meta:      "test",
+		Timestamp: time.Now(),
+	})
+
+	plugin.Shutdown(nil)
+	assert.Equal(t, 0, len(eventClient.eventsReceived))
+}

--- a/grpc/emitter_test.go
+++ b/grpc/emitter_test.go
@@ -22,8 +22,9 @@ func init() {
 }
 
 type mockClient struct {
-	eventCount int
-	totalBytes uint64
+	eventCount     int
+	totalBytes     uint64
+	eventsReceived []*pbmetering.Event
 }
 
 func (c *mockClient) Emit(ctx context.Context, in *pbmetering.Events, opts ...grpc.CallOption) (*emptypb.Empty, error) {
@@ -31,6 +32,10 @@ func (c *mockClient) Emit(ctx context.Context, in *pbmetering.Events, opts ...gr
 	for _, event := range in.Events {
 		c.totalBytes += uint64(event.Metrics[0].Value)
 	}
+	if c.eventsReceived == nil {
+		c.eventsReceived = make([]*pbmetering.Event, 0)
+	}
+	c.eventsReceived = append(c.eventsReceived, in.Events...)
 	return nil, nil
 }
 
@@ -90,4 +95,67 @@ func TestAuthenticatorPlugin_ContinuousAuthenticate(t *testing.T) {
 			assert.Equal(t, test.expectTotalBytes, eventClient.totalBytes)
 		})
 	}
+}
+
+func TestNetworkOverride(t *testing.T) {
+
+	ctx := context.Background()
+	eventClient := &mockClient{}
+
+	config := &Config{
+		Endpoint:   "localhost:9000",
+		Delay:      100 * time.Millisecond,
+		BufferSize: 100,
+		Network:    "eth-testnet",
+	}
+	plugin, err := newWithClient(config, eventClient, eventClient.Close, zlog)
+	require.NoError(t, err)
+
+	plugin.Emit(ctx, dmetering.Event{
+		Endpoint: "sf.firehose.v1/Blocks",
+		Metrics: map[string]float64{
+			"requests": 1,
+		},
+		UserID:    "0bizy1111111111111111",
+		ApiKeyID:  "2323232323232323232323232323232323232323232323232323232323232323",
+		IpAddress: "192.168.1.1",
+		Network:   "eth-mainnet",
+		Meta:      "test",
+		Timestamp: time.Now(),
+	})
+
+	plugin.Shutdown(nil)
+	assert.Equal(t, 1, len(eventClient.eventsReceived))
+	assert.Equal(t, "eth-testnet", eventClient.eventsReceived[0].Network)
+}
+
+func TestNetworkIncluded(t *testing.T) {
+
+	ctx := context.Background()
+	eventClient := &mockClient{}
+
+	config := &Config{
+		Endpoint:   "localhost:9000",
+		Delay:      100 * time.Millisecond,
+		BufferSize: 100,
+	}
+	plugin, err := newWithClient(config, eventClient, eventClient.Close, zlog)
+	require.NoError(t, err)
+
+	plugin.Emit(ctx, dmetering.Event{
+		Endpoint: "sf.firehose.v1/Blocks",
+		Metrics: map[string]float64{
+			"requests": 1,
+		},
+		UserID:    "0bizy1111111111111111",
+		ApiKeyID:  "2323232323232323232323232323232323232323232323232323232323232323",
+		IpAddress: "192.168.1.1",
+		Network:   "eth-mainnet",
+		Meta:      "test",
+		Timestamp: time.Now(),
+	})
+
+	plugin.Shutdown(nil)
+	assert.Equal(t, 1, len(eventClient.eventsReceived))
+	assert.Equal(t, "eth-mainnet", eventClient.eventsReceived[0].Network)
 }

--- a/metering.go
+++ b/metering.go
@@ -14,6 +14,7 @@ import (
 
 type Event struct {
 	Endpoint         string             `json:"endpoint"`
+	Network          string             `json:"network"` // can be omitted if the emitter is set up with a global network config
 	Metrics          map[string]float64 `json:"metrics,omitempty"`
 	OutputModuleHash string             `json:"output_module_hash,omitempty"` //substreams-only field
 
@@ -38,6 +39,7 @@ func (ev Event) MarshalLogObject(enc zapcore.ObjectEncoder) error {
 	}
 
 	enc.AddString("endpoint", ev.Endpoint)
+	enc.AddString("network", ev.Network)
 	enc.AddTime("timestamp", ev.Timestamp)
 
 	for k, v := range ev.Metrics {
@@ -47,10 +49,10 @@ func (ev Event) MarshalLogObject(enc zapcore.ObjectEncoder) error {
 	return nil
 }
 
-func (ev Event) ToProto(network string) *pbmetering.Event {
+func (ev Event) ToProto() *pbmetering.Event {
 	pbev := new(pbmetering.Event)
 	pbev.Endpoint = ev.Endpoint
-	pbev.Network = network
+	pbev.Network = ev.Network
 	pbev.OutputModuleHash = ev.OutputModuleHash
 	pbev.Timestamp = timestamppb.New(ev.Timestamp)
 	pbev.UserId = ev.UserID


### PR DESCRIPTION
This allows to include the network as part of the event, which is useful in case the emitting source is multi network. This means:

* a `network` field has been added to `dmetering.Event`
* the `network` query parameter is not required anymore, but optional
* if the network is passed as a config query parameter it will override the `network` field of the given dmetering.Event`, this ensures backwards compatibility